### PR TITLE
Ignore invalid IWMPMetadataPicture from WM/Picture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,9 @@ build/
 [Bb]in/
 [Oo]bj/
 
+# Visual Studio 2015/2017 cache/options directory
+.vs/
+
 # MSTest test Results
 [Tt]est[Rr]esult*/
 [Bb]uild[Ll]og.*

--- a/NowPlayingLib.Sample/Views/MainWindow.xaml
+++ b/NowPlayingLib.Sample/Views/MainWindow.xaml
@@ -58,7 +58,7 @@
         </Style>
         <l:VisibilityAndBooleanConverter x:Key="VisibilityAndBooleanConverter" ConvertWhenTrue="Visible" ConvertWhenFalse="Collapsed" />
     </Window.Resources>
-    <Grid Height="300" Width="300">
+    <Grid Height="300" Width="300" UseLayoutRounding="True">
         <Grid.Effect>
             <DropShadowEffect BlurRadius="15" Direction="-90" RenderingBias="Quality" ShadowDepth="4"/>
         </Grid.Effect>

--- a/NowPlayingLib/WindowsMediaPlayer.cs
+++ b/NowPlayingLib/WindowsMediaPlayer.cs
@@ -111,16 +111,19 @@ namespace NowPlayingLib
             Closed?.Invoke(this, EventArgs.Empty);
         }
 
-        private Task<Stream> GetArtwork(IWMPMetadataPicture artwork)
+        private async Task<Stream> GetArtwork(IWMPMetadataPicture artwork)
         {
             using (ComWrapper.Create(artwork))
             {
                 var cache = NativeMethods.GetUrlCacheEntryInfo(artwork.URL);
-                return ReadFile(cache.LocalFileName).ContinueWith(task =>
+                try
+                {
+                    return await ReadFile(cache.LocalFileName);
+                }
+                finally
                 {
                     NativeMethods.DeleteUrlCacheEntry(cache.SourceUrlName);
-                    return task.Result;
-                });
+                }
             }
         }
 

--- a/NowPlayingLib/iTunes.cs
+++ b/NowPlayingLib/iTunes.cs
@@ -80,17 +80,20 @@ namespace NowPlayingLib
             Closed?.Invoke(this, EventArgs.Empty);
         }
 
-        private Task<Stream> GetArtwork(IITArtwork artwork)
+        private async Task<Stream> GetArtwork(IITArtwork artwork)
         {
             using (ComWrapper.Create(artwork))
             {
                 string path = Path.GetTempFileName();
-                artwork.SaveArtworkToFile(path);
-                return ReadFile(path).ContinueWith(task =>
+                try
+                {
+                    artwork.SaveArtworkToFile(path);
+                    return await ReadFile(path);
+                }
+                finally
                 {
                     File.Delete(path);
-                    return task.Result;
-                });
+                }
             }
         }
 


### PR DESCRIPTION
Windows Media Player seems to throw an `ArgumentException` when it tries to retrieve a WM/Picture entry that it cannot handle properly for some reason. With this patch, those images are simply ignored when referenced.